### PR TITLE
Spark 3.0, compiling scala 2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ val words = model.transform(df)
 
 + 1.0 - Basic parser and reference data
 + 2.0 - Adding Goose library packaged for Spark / Scala 2.11
++ 3.0 - Spark 3.0 and Scala 2.12
 
 ## Authors
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <name>gdelt-spark</name>
   <groupId>com.aamend.spark</groupId>
   <artifactId>spark-gdelt</artifactId>
-  <version>2.2-SNAPSHOT</version>
+  <version>3.0-SNAPSHOT</version>
   <url>https://github.com/aamend/spark-gdelt</url>
   <description>Working with GDELT from Spark
   environment</description>
@@ -54,9 +54,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <properties>
     <project.build.sourceEncoding>
     UTF-8</project.build.sourceEncoding>
-    <scala.version>2.11.12</scala.version>
-    <scala.binary.version>2.11</scala.binary.version>
-    <spark.version>2.4.4</spark.version>
+    <scala.version>2.12.8</scala.version>
+    <scala.binary.version>2.12</scala.binary.version>
+    <spark.version>3.0.0</spark.version>
     <java.version>1.8</java.version>
   </properties>
   <dependencies>
@@ -129,7 +129,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <version>2.2.6</version>
+      <version>3.1.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -248,7 +248,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                   <exclude>joda-time:joda-time</exclude>
                   <exclude>commons-lang:commons-lang</exclude>
                   <exclude>
-                  com.typesafe.scala-logging:scala-logging_2.11</exclude>
+                  com.typesafe.scala-logging:scala-logging_2.12</exclude>
                 </excludes>
               </artifactSet>
               <transformers>


### PR DESCRIPTION
@lamastex I have to urgently compile GDELT for Spark 3.x / Scala 2.12. 
I've tested this code change on databricks runtime 7.X and ensured both the parser and HTML fetching work. New changes can be merged against 3.X later.